### PR TITLE
Three CIFAR-10 CNN examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,12 @@ $(eval $(call add_executable,dll_mnist_rnn,examples/src/mnist_rnn.cpp))
 $(eval $(call add_executable_set,dll_mnist_rnn,dll_mnist_rnn))
 $(eval $(call add_executable,dll_mnist_lstm,examples/src/mnist_lstm.cpp))
 $(eval $(call add_executable_set,dll_mnist_lstm,dll_mnist_lstm))
+$(eval $(call add_executable,dll_cifar10_cnn_small,examples/src/cifar10_cnn_small.cpp))
+$(eval $(call add_executable_set,dll_cifar10_cnn_small,dll_cifar10_cnn_small))
+$(eval $(call add_executable,dll_cifar10_cnn_med,examples/src/cifar10_cnn_med.cpp))
+$(eval $(call add_executable_set,dll_cifar10_cnn_med,dll_cifar10_cnn_med))
+$(eval $(call add_executable,dll_cifar10_cnn_big,examples/src/cifar10_cnn_big.cpp))
+$(eval $(call add_executable_set,dll_cifar10_cnn_big,dll_cifar10_cnn_big))
 
 $(eval $(call add_executable_set,dll_perf_paper,dll_perf_paper))
 $(eval $(call add_executable_set,dll_perf_paper_conv,dll_perf_paper_conv))
@@ -355,9 +361,9 @@ release_debug_workbench: release_debug/bin/dll_sgd_perf release_debug/bin/dll_co
 release_workbench: release/bin/dll_sgd_perf release/bin/dll_conv_sgd_perf release/bin/dll_imagenet_perf release/bin/dll_sgd_debug release/bin/dll_dae release/bin/dll_rbm_dae release/bin/dll_perf_paper release/bin/dll_perf_paper_conv release/bin/dll_perf_conv release/bin/dll_conv_types release/bin/dll_dyn_perf
 
 # Build sets for the examples
-debug_examples: debug/bin/dll_mnist_mlp debug/bin/dll_mnist_cnn debug/bin/dll_mnist_ae debug/bin/dll_mnist_deep_ae debug/bin/dll_mnist_dbn debug/bin/dll_mnist_cdbn
-release_debug_examples: release_debug/bin/dll_mnist_mlp release_debug/bin/dll_mnist_cnn release_debug/bin/dll_mnist_ae release_debug/bin/dll_mnist_deep_ae release_debug/bin/dll_mnist_dbn release_debug/bin/dll_mnist_cdbn
-release_examples: release/bin/dll_mnist_mlp release/bin/dll_mnist_cnn release/bin/dll_mnist_ae release/bin/dll_mnist_deep_ae release/bin/dll_mnist_dbn release/bin/dll_mnist_cdbn
+debug_examples: debug/bin/dll_mnist_mlp debug/bin/dll_mnist_cnn debug/bin/dll_mnist_ae debug/bin/dll_mnist_deep_ae debug/bin/dll_mnist_dbn debug/bin/dll_mnist_cdbn debug/bin/dll_cifar10_cnn_small debug/bin/dll_cifar10_cnn_med debug/bin/dll_cifar10_cnn_big
+release_debug_examples: release_debug/bin/dll_mnist_mlp release_debug/bin/dll_mnist_cnn release_debug/bin/dll_mnist_ae release_debug/bin/dll_mnist_deep_ae release_debug/bin/dll_mnist_dbn release_debug/bin/dll_mnist_cdbn release_debug/bin/dll_cifar10_cnn_small release_debug/bin/dll_cifar10_cnn_med release_debug/bin/dll_cifar10_cnn_big
+release_examples: release/bin/dll_mnist_mlp release/bin/dll_mnist_cnn release/bin/dll_mnist_ae release/bin/dll_mnist_deep_ae release/bin/dll_mnist_dbn release/bin/dll_mnist_cdbn release/bin/dll_cifar10_cnn_small release/bin/dll_cifar10_cnn_med release/bin/dll_cifar10_cnn_big
 
 # Build sets for perf examples
 debug_examples_perf: debug/bin/dll_mnist_mlp_perf debug/bin/dll_mnist_cnn_perf debug/bin/dll_mnist_cnn_bn_perf debug/bin/dll_mnist_ae_perf debug/bin/dll_mnist_deep_ae_perf debug/bin/dll_mnist_dbn_perf debug/bin/dll_mnist_cdbn_perf

--- a/examples/src/cifar10_cnn_big.cpp
+++ b/examples/src/cifar10_cnn_big.cpp
@@ -5,8 +5,6 @@
 //  http://opensource.org/licenses/MIT)
 //=======================================================================
 
-#define ETL_COUNTERS
-#define ETL_GPU_TOOLS
 #define ETL_GPU_POOL
 
 #include <dll/neural/conv/conv_same_layer.hpp>
@@ -50,15 +48,11 @@ int main(int /*argc*/, char* /*argv*/ []) {
     dbn->momentum = 0.9;
     dbn->goal = -1.0;
 
-    dbn->display();
+    dbn->display_pretty();
 
     dbn->fine_tune(dataset.train(), 5);
 
     dbn->evaluate(dataset.test());
-
-    dll::dump_timers_pretty();
-
-    etl::dump_counters_pretty();
 
     return 0;
 }

--- a/examples/src/cifar10_cnn_big.cpp
+++ b/examples/src/cifar10_cnn_big.cpp
@@ -1,0 +1,64 @@
+//=======================================================================
+// Copyright (c) 2016 Baptiste Wicht
+// Distributed under the terms of the MIT License.
+// (See accompanying file LICENSE or copy at
+//  http://opensource.org/licenses/MIT)
+//=======================================================================
+
+#define ETL_COUNTERS
+#define ETL_GPU_TOOLS
+#define ETL_GPU_POOL
+
+#include <dll/neural/conv/conv_same_layer.hpp>
+
+#include "dll/neural/dense/dense_layer.hpp"
+#include "dll/pooling/mp_layer.hpp"
+#include "dll/network.hpp"
+#include "dll/datasets.hpp"
+
+int main(int /*argc*/, char* /*argv*/ []) {
+    // Load the dataset
+    auto dataset = dll::make_cifar10_dataset(dll::batch_size<256>{}, dll::scale_pre<255>{});
+
+    /*
+     * 5x5 Same -> 3x3 Same -> MP -> 5x5 Same -> 3x3 Same -> MP -> 3x3 Same -> 3x3 Same -> MP -> FCNN
+     */
+    using dbn_t = dll::dbn_desc<
+            dll::dbn_layers<
+                    dll::conv_same_layer<3, 32, 32, 12, 5, 5, dll::relu>,
+                    dll::conv_same_layer<12, 32, 32, 12, 3, 3, dll::relu>,
+                    dll::mp_3d_layer<12, 32, 32, 1, 2, 2>,
+                    dll::conv_same_layer<12, 16, 16, 24, 5, 5, dll::relu>,
+                    dll::conv_same_layer<24, 16, 16, 24, 3, 3, dll::relu>,
+                    dll::mp_3d_layer<24, 16, 16, 1, 2, 2>,
+                    dll::conv_same_layer<24, 8, 8, 48, 3, 3, dll::relu>,
+                    dll::conv_same_layer<48, 8, 8, 48, 3, 3, dll::relu>,
+                    dll::mp_3d_layer<48, 8, 8, 1, 2, 2>,
+                    dll::dense_layer<48 * 4 * 4, 64, dll::relu>,
+                    dll::dense_layer<64, 10, dll::softmax>
+            >,
+            dll::updater<dll::updater_type::MOMENTUM>,
+            dll::batch_size<256>,
+            dll::no_batch_display,
+            dll::no_epoch_error
+    >::dbn_t;
+
+    auto dbn = std::make_unique<dbn_t>();
+
+    dbn->learning_rate = 0.001;
+    dbn->initial_momentum = 0.9;
+    dbn->momentum = 0.9;
+    dbn->goal = -1.0;
+
+    dbn->display();
+
+    dbn->fine_tune(dataset.train(), 5);
+
+    dbn->evaluate(dataset.test());
+
+    dll::dump_timers_pretty();
+
+    etl::dump_counters_pretty();
+
+    return 0;
+}

--- a/examples/src/cifar10_cnn_med.cpp
+++ b/examples/src/cifar10_cnn_med.cpp
@@ -1,0 +1,60 @@
+//=======================================================================
+// Copyright (c) 2016 Baptiste Wicht
+// Distributed under the terms of the MIT License.
+// (See accompanying file LICENSE or copy at
+//  http://opensource.org/licenses/MIT)
+//=======================================================================
+
+#define ETL_COUNTERS
+#define ETL_GPU_TOOLS
+#define ETL_GPU_POOL
+
+#include "dll/neural/conv/conv_layer.hpp"
+#include "dll/neural/dense/dense_layer.hpp"
+#include "dll/pooling/mp_layer.hpp"
+#include "dll/network.hpp"
+#include "dll/datasets.hpp"
+
+int main(int /*argc*/, char* /*argv*/ []) {
+    // Load the dataset
+    auto dataset = dll::make_cifar10_dataset(dll::batch_size<256>{}, dll::scale_pre<255>{});
+
+    /*
+     * 3x3 -> 3x3 -> MP -> 3x3 -> 3x3 -> MP -> FCNN
+     */
+    using dbn_t = dll::dbn_desc<
+            dll::dbn_layers<
+                    dll::conv_layer<3, 32, 32, 12, 3, 3, dll::relu>,
+                    dll::conv_layer<12, 30, 30, 12, 3, 3, dll::relu>,
+                    dll::mp_3d_layer<12, 28, 28, 1, 2, 2>,
+                    dll::conv_layer<12, 14, 14, 24, 3, 3, dll::relu>,
+                    dll::conv_layer<24, 12, 12, 24, 3, 3, dll::relu>,
+                    dll::mp_3d_layer<24, 10, 10, 1, 2, 2>,
+                    dll::dense_layer<24 * 5 * 5, 64, dll::relu>,
+                    dll::dense_layer<64, 10, dll::softmax>
+            >,
+            dll::updater<dll::updater_type::MOMENTUM>,
+            dll::batch_size<256>,
+            dll::no_batch_display,
+            dll::no_epoch_error
+    >::dbn_t;
+
+    auto dbn = std::make_unique<dbn_t>();
+
+    dbn->learning_rate = 0.001;
+    dbn->initial_momentum = 0.9;
+    dbn->momentum = 0.9;
+    dbn->goal = -1.0;
+
+    dbn->display();
+
+    dbn->fine_tune(dataset.train(), 5);
+
+    dbn->evaluate(dataset.test());
+
+    dll::dump_timers_pretty();
+
+    etl::dump_counters_pretty();
+
+    return 0;
+}

--- a/examples/src/cifar10_cnn_med.cpp
+++ b/examples/src/cifar10_cnn_med.cpp
@@ -5,8 +5,6 @@
 //  http://opensource.org/licenses/MIT)
 //=======================================================================
 
-#define ETL_COUNTERS
-#define ETL_GPU_TOOLS
 #define ETL_GPU_POOL
 
 #include "dll/neural/conv/conv_layer.hpp"
@@ -46,15 +44,11 @@ int main(int /*argc*/, char* /*argv*/ []) {
     dbn->momentum = 0.9;
     dbn->goal = -1.0;
 
-    dbn->display();
+    dbn->display_pretty();
 
     dbn->fine_tune(dataset.train(), 5);
 
     dbn->evaluate(dataset.test());
-
-    dll::dump_timers_pretty();
-
-    etl::dump_counters_pretty();
 
     return 0;
 }

--- a/examples/src/cifar10_cnn_small.cpp
+++ b/examples/src/cifar10_cnn_small.cpp
@@ -1,0 +1,55 @@
+//=======================================================================
+// Copyright (c) 2016 Baptiste Wicht
+// Distributed under the terms of the MIT License.
+// (See accompanying file LICENSE or copy at
+//  http://opensource.org/licenses/MIT)
+//=======================================================================
+
+#define ETL_COUNTERS
+#define ETL_GPU_TOOLS
+#define ETL_GPU_POOL
+
+#include "dll/neural/conv/conv_layer.hpp"
+#include "dll/neural/dense/dense_layer.hpp"
+#include "dll/pooling/mp_layer.hpp"
+#include "dll/network.hpp"
+#include "dll/datasets.hpp"
+
+int main(int /*argc*/, char* /*argv*/ []) {
+    // Load the dataset
+    auto dataset = dll::make_cifar10_dataset(dll::batch_size<256>{}, dll::scale_pre<255>{});
+
+    using dbn_t = dll::dbn_desc<
+            dll::dbn_layers<
+                    dll::conv_layer<3, 32, 32, 12, 5, 5, dll::relu>,
+                    dll::mp_3d_layer<12, 28, 28, 1, 2, 2>,
+                    dll::conv_layer<12, 14, 14, 24, 3, 3, dll::relu>,
+                    dll::mp_3d_layer<24, 12, 12, 1, 2, 2>,
+                    dll::dense_layer<24 * 6 * 6, 64, dll::relu>,
+                    dll::dense_layer<64, 10, dll::softmax>
+            >,
+            dll::updater<dll::updater_type::MOMENTUM>,
+            dll::batch_size<256>,
+            dll::no_batch_display,
+            dll::no_epoch_error
+    >::dbn_t;
+
+    auto dbn = std::make_unique<dbn_t>();
+
+    dbn->learning_rate = 0.001;
+    dbn->initial_momentum = 0.9;
+    dbn->momentum = 0.9;
+    dbn->goal = -1.0;
+
+    dbn->display();
+
+    dbn->fine_tune(dataset.train(), 5);
+
+    dbn->evaluate(dataset.test());
+
+    dll::dump_timers_pretty();
+
+    etl::dump_counters_pretty();
+
+    return 0;
+}

--- a/examples/src/cifar10_cnn_small.cpp
+++ b/examples/src/cifar10_cnn_small.cpp
@@ -5,8 +5,6 @@
 //  http://opensource.org/licenses/MIT)
 //=======================================================================
 
-#define ETL_COUNTERS
-#define ETL_GPU_TOOLS
 #define ETL_GPU_POOL
 
 #include "dll/neural/conv/conv_layer.hpp"
@@ -41,15 +39,11 @@ int main(int /*argc*/, char* /*argv*/ []) {
     dbn->momentum = 0.9;
     dbn->goal = -1.0;
 
-    dbn->display();
+    dbn->display_pretty();
 
     dbn->fine_tune(dataset.train(), 5);
 
     dbn->evaluate(dataset.test());
-
-    dll::dump_timers_pretty();
-
-    etl::dump_counters_pretty();
 
     return 0;
 }


### PR DESCRIPTION
This PR contains three CNN examples of different sizes that use the CIFAR-10 dataset.
`cifar10_cnn_small.cpp` was taken from [your _frameworks_ repository](https://github.com/wichtounet/frameworks/blob/master/dll/src/experiment5.cpp), which served as a base for the other two sizes.
`cifar10_cnn_med.cpp` has 4 convolution layers, 2 Max-Pool 3D and two dense layers.
`cifar10_cnn_big.cpp` has 6 convolution layers, 3 Max-Pool 3D and two dense layers.